### PR TITLE
Update google-tts-api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "castv2-client": "^1.2.0",
-    "google-tts-api": "^0.0.2",
+    "google-tts-api": "^0.0.3",
     "mdns": "https://github.com/agnat/node_mdns/tarball/master",
     "mime-types": "^2.1.17"
   }


### PR DESCRIPTION
Allow npm to get new version of google-tts-api (0.0.3) to fix new api changes : https://github.com/zlargon/google-tts/issues/17

See here to understand why npm don't get the 0.0.3 version automatically.
https://github.com/npm/npm/issues/7240#issuecomment-72123684